### PR TITLE
12.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.17
+FROM postgres:12.18
 LABEL maintainer="HARUYAMA Seigo <haruyama@pacificporter.jp>"
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.11
+FROM postgres:12.17
 LABEL maintainer="HARUYAMA Seigo <haruyama@pacificporter.jp>"
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="HARUYAMA Seigo <haruyama@pacificporter.jp>"
 RUN apt-get update \
     && apt-get install -y curl make gcc postgresql-server-dev-12 libicu-dev \
     && cd /tmp \
-    && curl -L -O https://ja.osdn.net/dl/pgbigm/pg_bigm-1.2-20200228.tar.gz \
+    && curl -L -o pg_bigm-1.2-20200228.tar.gz https://github.com/pgbigm/pg_bigm/archive/refs/tags/v1.2-20200228.tar.gz \
     && tar zxf pg_bigm-1.2-20200228.tar.gz \
     && cd pg_bigm-1.2-20200228 \
     && make USE_PGXS=1 \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/postgres-bigm:12.17 .
+docker build -t pacificporter/postgres-bigm:12.18 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/postgres-bigm:12.17
+docker push pacificporter/postgres-bigm:12.18
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/postgres-bigm:12.11 .
+docker build -t pacificporter/postgres-bigm:12.17 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/postgres-bigm:12.11
+docker push pacificporter/postgres-bigm:12.17
 ```


### PR DESCRIPTION
12.17 が公式イメージがもう使えない？ようで自動で 12.18 になってしまうので 12.18 にします。
また https://ja.osdn.net/ の調子が悪いようなので GitHub に置き換えています。
