### PR TITLE
platform 指定追加と上書きする設定ファイルの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update \
     && cd pg_bigm-1.2-20200228 \
     && make USE_PGXS=1 \
     && make USE_PGXS=1 install \
-    && echo shared_preload_libraries='pg_bigm' >> /var/lib/postgresql/data/postgresql.conf \
+    && echo shared_preload_libraries='pg_bigm' >> /usr/share/postgresql/postgresql.conf.sample \
     && rm -fr /tmp/pg_bigm-1.2-20200228 /tmp/pg_bigm-1.2-20200228.tar.gz \
     && apt-get purge -y curl make gcc postgresql-server-dev-12 libicu-dev \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 STOPSIGNAL SIGINT
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.18
+FROM --platform=linux/amd64 postgres:12.18
 LABEL maintainer="HARUYAMA Seigo <haruyama@pacificporter.jp>"
 
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## build
 
 ```
-docker build -t pacificporter/postgres-bigm:12.18 .
+docker build --platform linux/amd64 -t pacificporter/postgres-bigm:12.18 .
 ```
 
 ## push

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## build
 
 ```
-docker build --platform linux/amd64 -t pacificporter/postgres-bigm:12.18 .
+docker build -t pacificporter/postgres-bigm:12.18 .
 ```
 
 ## push


### PR DESCRIPTION
M1 Mac 環境で platform をつけずにビルドしたところ arm64 になってしまったので明示するようにしました。
加えて、 `/var/lib/postgresql/data/postgresql.conf` を Dockerfile で書き換えると起動時に問題があったため、コピー元である `/usr/share/postgresql/postgresql.conf.sample` に追記するようにしました。